### PR TITLE
Updated readme + version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,6 @@ limiter = InMemoryLimiter(storage_uri="redis://localhost:6379")
 limiter.init_app(app=app)
 ```
 
-In addition to this, ```init_app``` allows you to set several in-memory useful variables.
-This lets you dynamically configure the rate limiter using objects from the Flask
-application context - such as ```app.config``` values. This is not possible with
-the base class. Currently, the supported variable overrides are:
-
-- storage_uri
-- key_prefix
-
 # Developing
 __The build pipeline requires your tests to pass and code to be formatted__
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="flask-api-tools",
-    version="1.0.7",
+    version="1.0.8",
     author="ScholarPack",
     author_email="dev@scholarpack.com",
     description="Tooling to assist with building Flask APIs",
@@ -14,7 +14,7 @@ setuptools.setup(
     url="https://github.com/ScholarPack/flask-api-tools",
     packages=setuptools.find_packages(),
     classifiers=[
-        "Development Status :: 4 - Beta",
+        "Development Status :: 5 - Production/Stable",
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",


### PR DESCRIPTION
Removed no longer valid note from readme regarding `init_app` configuration handling.