### PR TITLE
Changed rate limiter to fallback to memory backed storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ The ```InMemoryLimiter``` class is an extension of Flask-Limiter. This class
 implements storage-backed rate limiting. You'll need to follow the rate limiting steps
 outlined in [Flask-Limiter](https://flask-limiter.readthedocs.io/en/stable/), and 
 you must provide a ```RATELIMIT_STORAGE_URL``` to a redis (or other in-memory data
-structure) instance. 
+structure) instance. If you enabled the in-memory fallback of Flask-Limiter,
+this class will simply log the errors and then switchover instead.
 
 This class attaches any existing Flask log handlers to Flask-Limiter.
 

--- a/flask_api_tools/rate_limiting/in_memory_limiter.py
+++ b/flask_api_tools/rate_limiting/in_memory_limiter.py
@@ -32,14 +32,25 @@ class InMemoryLimiter(Limiter):
         """
         Check the storage backed is connected correctly
         :return: None
-        :raise ConfigurationError: if storage is incorrectly configured
+        :raise ConfigurationError: if storage is incorrectly configured (and no fallback is enabled)
         """
         if self.enabled:
-            self.logger.debug("Starting to check in-memory backend storage")
+            self.logger.debug(
+                f"Starting to check in-memory backend storage: {self._storage}"
+            )
             if not self._storage.check():
-                self.logger.critical("Invalid or inaccessible storage configuration")
-                raise ConfigurationError(
-                    "Invalid or inaccessible storage configuration"
-                )
+                if self._in_memory_fallback_enabled:
+                    self.logger.error(
+                        f"Storage schema inaccessible - falling back to {self._storage}"
+                    )
+                else:
+                    self.logger.critical(
+                        f"Invalid or inaccessible storage configuration: {self._storage}"
+                    )
+                    raise ConfigurationError(
+                        "Invalid or inaccessible storage configuration"
+                    )
 
-            self.logger.debug("In-memory backend storage operating correctly")
+            self.logger.debug(
+                f"In-memory backend storage operating correctly: {self._storage}"
+            )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="flask-api-tools",
-    version="1.0.9",
+    version="1.0.10",
     author="ScholarPack",
     author_email="dev@scholarpack.com",
     description="Tooling to assist with building Flask APIs",


### PR DESCRIPTION
Change to only raise `ConfigurationError` if there is no limiter storage fallback configured.