### PR TITLE
Expose Cerberus validation flags in DataSet

### DIFF
--- a/flask_api_tools/validators/README.md
+++ b/flask_api_tools/validators/README.md
@@ -25,7 +25,7 @@ schema = {
 
 ### DataSet
 The ```DataSet``` class is a friendly wrapper for the ```Validator``` class.
-This class is intended to be used for ensuring data that comes from another API matches a given format.
+This class is intended to be used for ensuring data that comes from another API matches a given format. The `DataSet` class is intended to be extended.
 
 Basic usage:
 ```python
@@ -68,6 +68,18 @@ If the API response is in the format:
 ```
 
 ```.validate_one``` and ```.validate_many``` should be used instead.
+
+Anything that extends `DataSet` also exposes the following, with the associated defaults:
+
+```python
+_allow_unknown: bool = False
+_ignore_none_values: bool = False
+_purge_readonly: bool = False
+_purge_unknown: bool = False
+_require_all: bool = False
+```
+
+These function exactly as documented in the [cerberus documentation](https://docs.python-cerberus.org/en/stable/validation-rules.html)
 
 ### SanitisedDataSet
 The ```SanitisedDataSet``` class is a friendly wrapper for a dictionary.

--- a/flask_api_tools/validators/data_set.py
+++ b/flask_api_tools/validators/data_set.py
@@ -5,11 +5,11 @@ from .validator import Validator
 
 class DataSet(dict):
 
-    allow_unknown: bool = False
-    ignore_none_values: bool = False
-    purge_readonly: bool = False
-    purge_unknown: bool = False
-    require_all: bool = False
+    _allow_unknown: bool = False
+    _ignore_none_values: bool = False
+    _purge_readonly: bool = False
+    _purge_unknown: bool = False
+    _require_all: bool = False
     schema: Dict = {}
 
     def __init__(self, *args, **kwargs):
@@ -51,11 +51,11 @@ class DataSet(dict):
 
         validator = Validator(
             schema=cls.schema,
-            allow_unknown=cls.allow_unknown,
-            ignore_none_values=cls.ignore_none_values,
-            purge_readonly=cls.purge_readonly,
-            purge_unknown=cls.purge_unknown,
-            require_all=cls.require_all,
+            allow_unknown=cls._allow_unknown,
+            ignore_none_values=cls._ignore_none_values,
+            purge_readonly=cls._purge_readonly,
+            purge_unknown=cls._purge_unknown,
+            require_all=cls._require_all,
         )
 
         if not validator.validate(data[0]):
@@ -80,11 +80,11 @@ class DataSet(dict):
 
         validator = Validator(
             schema=cls.schema,
-            allow_unknown=cls.allow_unknown,
-            ignore_none_values=cls.ignore_none_values,
-            purge_readonly=cls.purge_readonly,
-            purge_unknown=cls.purge_unknown,
-            require_all=cls.require_all,
+            allow_unknown=cls._allow_unknown,
+            ignore_none_values=cls._ignore_none_values,
+            purge_readonly=cls._purge_readonly,
+            purge_unknown=cls._purge_unknown,
+            require_all=cls._require_all,
         )
 
         for d in data:

--- a/flask_api_tools/validators/data_set.py
+++ b/flask_api_tools/validators/data_set.py
@@ -5,6 +5,11 @@ from .validator import Validator
 
 class DataSet(dict):
 
+    allow_unknown: bool = False
+    ignore_none_values: bool = False
+    purge_readonly: bool = False
+    purge_unknown: bool = False
+    require_all: bool = False
     schema: Dict = {}
 
     def __init__(self, *args, **kwargs):
@@ -44,9 +49,16 @@ class DataSet(dict):
         if not data:
             return {}
 
-        validator = Validator()
+        validator = Validator(
+            schema=cls.schema,
+            allow_unknown=cls.allow_unknown,
+            ignore_none_values=cls.ignore_none_values,
+            purge_readonly=cls.purge_readonly,
+            purge_unknown=cls.purge_unknown,
+            require_all=cls.require_all,
+        )
 
-        if not validator.validate(data[0], cls.schema):
+        if not validator.validate(data[0]):
             raise DocumentError(validator.errors)
 
         return cls(validator.document)
@@ -66,10 +78,17 @@ class DataSet(dict):
         if not data:
             return collection
 
-        validator = Validator()
+        validator = Validator(
+            schema=cls.schema,
+            allow_unknown=cls.allow_unknown,
+            ignore_none_values=cls.ignore_none_values,
+            purge_readonly=cls.purge_readonly,
+            purge_unknown=cls.purge_unknown,
+            require_all=cls.require_all,
+        )
 
         for d in data:
-            if validator.validate(d, cls.schema):
+            if validator.validate(d):
                 collection.append(cls(validator.document))
             else:
                 raise DocumentError(validator.errors)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="flask-api-tools",
-    version="1.1.0",
+    version="1.2.0",
     author="ScholarPack",
     author_email="dev@scholarpack.com",
     description="Tooling to assist with building Flask APIs",

--- a/tests/validators/test_data_set.py
+++ b/tests/validators/test_data_set.py
@@ -47,3 +47,100 @@ class TestDataSet:
         }
         with pytest.raises(DocumentError):
             ExampleDataSet.validate_object(example_raw_data)
+
+    def test_list_unknown_key(self):
+        example_raw_data = {
+            "unknown_key": "",
+        }
+        with pytest.raises(DocumentError):
+            ExampleDataSet.validate_objects([example_raw_data])
+
+    def test_validate_list(self):
+        example_raw_data = {
+            "key_string": "abc",
+            "key_none_string": None,
+            "key_nullable_string": "",
+            "key_uuid_string": "7c674878-e544-431c-8c11-f11565299cac",
+            "key_integer": 5,
+            "key_none_integer": None,
+            "key_nullable_integer": "",
+            "key_bool": "True",
+            "key_none_bool": None,
+        }
+        expected_data = {
+            "key_string": "abc",
+            "key_none_string": "",
+            "key_nullable_string": None,
+            "key_uuid_string": "7c674878-e544-431c-8c11-f11565299cac",
+            "key_integer": 5,
+            "key_none_integer": 0,
+            "key_nullable_integer": None,
+            "key_bool": True,
+            "key_none_bool": False,
+        }
+        validated_data_set = ExampleDataSet.validate_objects(
+            [example_raw_data, example_raw_data]
+        )
+        assert validated_data_set == [expected_data, expected_data]
+
+    def test_validate_data_object(self):
+        example_raw_data = {
+            "key_string": "abc",
+            "key_none_string": None,
+            "key_nullable_string": "",
+            "key_uuid_string": "7c674878-e544-431c-8c11-f11565299cac",
+            "key_integer": 5,
+            "key_none_integer": None,
+            "key_nullable_integer": "",
+            "key_bool": "True",
+            "key_none_bool": None,
+        }
+        expected_data = {
+            "key_string": "abc",
+            "key_none_string": "",
+            "key_nullable_string": None,
+            "key_uuid_string": "7c674878-e544-431c-8c11-f11565299cac",
+            "key_integer": 5,
+            "key_none_integer": 0,
+            "key_nullable_integer": None,
+            "key_bool": True,
+            "key_none_bool": False,
+        }
+        validated_data_set = ExampleDataSet.validate_one({"data": [example_raw_data]})
+        assert validated_data_set == expected_data
+
+    def test_validate_data_list(self):
+        example_raw_data = {
+            "key_string": "abc",
+            "key_none_string": None,
+            "key_nullable_string": "",
+            "key_uuid_string": "7c674878-e544-431c-8c11-f11565299cac",
+            "key_integer": 5,
+            "key_none_integer": None,
+            "key_nullable_integer": "",
+            "key_bool": "True",
+            "key_none_bool": None,
+        }
+        expected_data = {
+            "key_string": "abc",
+            "key_none_string": "",
+            "key_nullable_string": None,
+            "key_uuid_string": "7c674878-e544-431c-8c11-f11565299cac",
+            "key_integer": 5,
+            "key_none_integer": 0,
+            "key_nullable_integer": None,
+            "key_bool": True,
+            "key_none_bool": False,
+        }
+        validated_data_set = ExampleDataSet.validate_many(
+            {"data": [example_raw_data, example_raw_data]}
+        )
+        assert validated_data_set == [expected_data, expected_data]
+
+    def test_one_missing_data_key(self):
+        validate_data_set = ExampleDataSet.validate_one({"NOT_DATA": []})
+        assert validate_data_set == {}
+
+    def test_many_missing_data_key(self):
+        validate_data_set = ExampleDataSet.validate_many({"NOT_DATA": []})
+        assert validate_data_set == []


### PR DESCRIPTION
Exposed the following flags on the `DataSet` that are passed directly into the constructor of the `Validator`:

* allow_unknown
* ignore_none_values
* purge_readonly
* purge_unknown
* require_all

Also bump the version to 1.2.0 and increase test coverage on `DataSet`.

Already tested on `test-pypi`
